### PR TITLE
Update autoware_state_machine.cpp

### DIFF
--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -20,7 +20,7 @@
 namespace autoware_state_machine
 {
 
-#define DEBUG_THROTTLE_TIME   0.05
+#define DEBUG_THROTTLE_TIME  5000
 
 void AutowareStateMachine::onAwapiAutowareState(
   const tier4_api_msgs::msg::AwapiAutowareStatus::ConstSharedPtr msg_ptr)


### PR DESCRIPTION
DEBUG_THROTTLE_TIMEがsecondを前提として記載されているが、RCLCPP_*_THROTTLEで指定するdurationはmsが単位である
これまでは0.05msごとに表示されていたため、修正する
なお、0.05sに修正しても、50msで表示量が多いため、5000 ms -> 5secに修正する