### PR TITLE
fix: stop reason priority

### DIFF
--- a/include/autoware_state_machine/autoware_state_machine.hpp
+++ b/include/autoware_state_machine/autoware_state_machine.hpp
@@ -49,6 +49,16 @@ enum class ChangeStateReturnItem
   TRANSITION,
 };
 
+struct ReasonWithDistance
+{
+  std::string reason;
+  double distance;
+  explicit ReasonWithDistance(const std::string a_reason = "", const double a_distance = 0.0) {
+    reason = a_reason;
+    distance = a_distance;
+  }
+};
+
 class AutowareStateMachine : public rclcpp::Node
 {
 public:
@@ -180,6 +190,8 @@ private:
   void setEngageProcess(bool request, bool accept);
   std::pair<bool, bool> getEngageProcess(void);
   bool waitingForEngageAccept(void);
+  ReasonWithDistance getNearestStopReason(
+    const std::vector<tier4_planning_msgs::msg::StopReason> & stop_reasons);
 };
 
 }  // namespace autoware_state_machine

--- a/include/autoware_state_machine/autoware_state_machine.hpp
+++ b/include/autoware_state_machine/autoware_state_machine.hpp
@@ -49,16 +49,6 @@ enum class ChangeStateReturnItem
   TRANSITION,
 };
 
-struct ReasonWithDistance
-{
-  std::string reason;
-  double distance;
-  explicit ReasonWithDistance(const std::string a_reason = "", const double a_distance = 0.0) {
-    reason = a_reason;
-    distance = a_distance;
-  }
-};
-
 class AutowareStateMachine : public rclcpp::Node
 {
 public:
@@ -190,7 +180,7 @@ private:
   void setEngageProcess(bool request, bool accept);
   std::pair<bool, bool> getEngageProcess(void);
   bool waitingForEngageAccept(void);
-  ReasonWithDistance getNearestStopReason(
+  std::pair<std::string, double> getNearestStopReason(
     const std::vector<tier4_planning_msgs::msg::StopReason> & stop_reasons);
 };
 

--- a/include/autoware_state_machine/autoware_state_machine.hpp
+++ b/include/autoware_state_machine/autoware_state_machine.hpp
@@ -180,7 +180,7 @@ private:
   void setEngageProcess(bool request, bool accept);
   std::pair<bool, bool> getEngageProcess(void);
   bool waitingForEngageAccept(void);
-  std::pair<std::string, double> getNearestStopReason(
+  std::pair<std::string, double> getNearestStopReasonWithPriority(
     const std::vector<tier4_planning_msgs::msg::StopReason> & stop_reasons);
 };
 

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -31,14 +31,14 @@ void AutowareStateMachine::onAwapiAutowareState(
   cur_control_mode_ = msg_ptr->control_mode;
   cur_emergency_holding_ = msg_ptr->hazard_status.status.emergency_holding;
 
-  const auto res = getNearestStopReason(msg_ptr->stop_reason.stop_reasons);
+  const auto res = getNearestStopReasonWithPriority(msg_ptr->stop_reason.stop_reasons);
   stop_reason_ = res.first;
   cur_dist_to_stop_pose_ = res.second;
   // RCLCPP_INFO(this->get_logger(), "final stop_reason: %s, distance: %lf", stop_reason_.c_str(), cur_dist_to_stop_pose_);
   ChangeState();
 }
 
-std::pair<std::string, double> AutowareStateMachine::getNearestStopReason(
+std::pair<std::string, double> AutowareStateMachine::getNearestStopReasonWithPriority(
   const std::vector<tier4_planning_msgs::msg::StopReason> & stop_reasons)
 {
   using StopReason = tier4_planning_msgs::msg::StopReason;

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include <queue>
 #include "autoware_state_machine/autoware_state_machine.hpp"
 
 namespace autoware_state_machine
@@ -25,48 +26,52 @@ namespace autoware_state_machine
 void AutowareStateMachine::onAwapiAutowareState(
   const tier4_api_msgs::msg::AwapiAutowareStatus::ConstSharedPtr msg_ptr)
 {
-  const auto current_time = this->now();
-  constexpr double double_epsilon = std::numeric_limits<double>::epsilon();
-
   pre_autoware_state_recv_time_ = msg_ptr->header.stamp;
   cur_autoware_state_ = msg_ptr->autoware_state;
   cur_control_mode_ = msg_ptr->control_mode;
   cur_emergency_holding_ = msg_ptr->hazard_status.status.emergency_holding;
 
-  /* Multiple "StopReasons" data are stored in the array. The storage order changes each time depending on the situation.
-     Finally, narrow down to one "StopReason" data, which is the highest priority.
-     The judgment process is as follows
-       - Check "SurrondObstacleCheck" with the highest priority.
-         In the "SurrondObstacleCheck", the distance information "dist_to_stop_pose" is not evaluated because the object is already approaching.
-       - For other "StopReasons", the one with the smallest distance information "dist_to_stop_pose" is given priority.
-     * Since it is a Float expression, the epsilon value is used because the matching comparison of 0 values is not valid. */
-  stop_reason_ = "";
-  cur_dist_to_stop_pose_ = dist_to_stop_pose_max_th_;
-  if (msg_ptr->stop_reason.stop_reasons.size() != 0) {
-    for (const auto & tmp_stop_reason : msg_ptr->stop_reason.stop_reasons) {
-      if (tmp_stop_reason.reason ==
-        tier4_planning_msgs::msg::StopReason::SURROUND_OBSTACLE_CHECK)
-      {
-        stop_reason_ = tier4_planning_msgs::msg::StopReason::SURROUND_OBSTACLE_CHECK;
-        cur_dist_to_stop_pose_ = 0.0;
-        break;
-      }
-
-      if (tmp_stop_reason.stop_factors.size() != 0) {
-        for (const auto & tmp_stop_factor : tmp_stop_reason.stop_factors) {
-          if (std::abs(tmp_stop_factor.dist_to_stop_pose) <= double_epsilon) {
-            cur_dist_to_stop_pose_ = 0.0;
-            stop_reason_ = tmp_stop_reason.reason;
-          } else if (tmp_stop_factor.dist_to_stop_pose <= cur_dist_to_stop_pose_) {
-            cur_dist_to_stop_pose_ = tmp_stop_factor.dist_to_stop_pose;
-            stop_reason_ = tmp_stop_reason.reason;
-          }
-        }  // for(const auto & tmp_stop_factor : tmp_stop_reason.stop_factors)
-      }  // if(tmp_stop_reason.stop_factors.size() != 0)
-    }  // for(const auto & tmp_stop_reason : msg_ptr->stop_reason.stop_reasons)
-  }  // if(msg_ptr->stop_reason.stop_reasons.size() != 0)
+  const auto &tmp = getNearestStopReason(msg_ptr->stop_reason.stop_reasons);
+  stop_reason_ = tmp.reason;
+  cur_dist_to_stop_pose_ = tmp.distance;
 
   ChangeState();
+}
+
+ReasonWithDistance AutowareStateMachine::getNearestStopReason(
+  const std::vector<tier4_planning_msgs::msg::StopReason> & stop_reasons)
+{
+  // 比較関数
+  auto compare =
+    [](ReasonWithDistance a, ReasonWithDistance b) -> bool {
+      // 優先度
+      // 1. SURROUND_OBSTACLE_CHECK
+      // 2. OBSTACLE_STOP
+      // 3. DETECTION_AREA
+      // 4. 距離が近い
+      if (b.reason == tier4_planning_msgs::msg::StopReason::SURROUND_OBSTACLE_CHECK)
+        return true;
+      else if (b.reason == tier4_planning_msgs::msg::StopReason::OBSTACLE_STOP)
+        return true;
+      else if (b.reason == tier4_planning_msgs::msg::StopReason::DETECTION_AREA)
+        return true;
+      else
+        return a.distance > b.distance;
+    };
+
+  std::priority_queue<ReasonWithDistance, std::vector<ReasonWithDistance>, decltype(compare)>
+    que{compare};
+
+  // 優先度付並び替え
+  for (const auto & reason : stop_reasons) {
+    for (const auto & factor : reason.stop_factors) {
+      // しきい値よりも遠い距離にある障害物は弾く
+      if (factor.dist_to_stop_pose < dist_to_stop_pose_max_th_)
+        que.push(ReasonWithDistance(reason.reason , factor.dist_to_stop_pose));
+    }
+  }
+
+  return !que.empty() ? que.top() : ReasonWithDistance();
 }
 
 void AutowareStateMachine::onAwapiVehicleState(

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -105,11 +105,6 @@ std::pair<std::string, double> AutowareStateMachine::getNearestStopReasonWithPri
   }
   const auto res = !que.empty() ? std::make_pair(que.top().reason, que.top().distance)
                       : std::make_pair("", 0.0);
-  // RCLCPP_INFO(this->get_logger(), "priority_queue");
-  // while(!que.empty()) {
-  //   RCLCPP_INFO(this->get_logger(), "stop_reason: %s, distance: %lf", que.top().reason.c_str(), que.top().distance);
-  //   que.pop();
-  // }
   return res;
 }
 

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -78,7 +78,7 @@ std::pair<std::string, double> AutowareStateMachine::getNearestStopReason(
   auto compare =
     [](const ReasonInfo & a, const ReasonInfo & b) -> bool {
       // 優先度
-      // 1. 距離がどちらとも1e-3（1mm）より小さい場合
+      // 1. 距離がどちらともほぼ0m（1e-3（1mm）より小さい）場合
       //    a. SURROUND_OBSTACLE_CHECK
       //    b. OBSTACLE_STOP
       //    c. DETECTION_AREA

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -34,7 +34,6 @@ void AutowareStateMachine::onAwapiAutowareState(
   const auto res = getNearestStopReasonWithPriority(msg_ptr->stop_reason.stop_reasons);
   stop_reason_ = res.first;
   cur_dist_to_stop_pose_ = res.second;
-  // RCLCPP_INFO(this->get_logger(), "final stop_reason: %s, distance: %lf", stop_reason_.c_str(), cur_dist_to_stop_pose_);
   ChangeState();
 }
 

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -31,11 +31,9 @@ void AutowareStateMachine::onAwapiAutowareState(
   cur_control_mode_ = msg_ptr->control_mode;
   cur_emergency_holding_ = msg_ptr->hazard_status.status.emergency_holding;
 
-  auto [stop_reason, cur_dist_to_stop_pose] =
-    getNearestStopReason(msg_ptr->stop_reason.stop_reasons);
-
-  stop_reason_ = stop_reason;
-  cur_dist_to_stop_pose_ = cur_dist_to_stop_pose;
+  const auto res = getNearestStopReason(msg_ptr->stop_reason.stop_reasons);
+  stop_reason_ = res.first;
+  cur_dist_to_stop_pose_ = res.second;
   // RCLCPP_INFO(this->get_logger(), "final stop_reason: %s, distance: %lf", stop_reason_.c_str(), cur_dist_to_stop_pose_);
   ChangeState();
 }


### PR DESCRIPTION
## Description
`/awapi/autoware/get/status` に格納されているstop_reasonにおいて、VTLとobstacle_stopが存在していてかつ両方の距離が0の場合、選択されるstop_reasonがチャタリングして音声発話にも影響が出ているため、修正を実施

修正においては、X1.eveで使用されているstop_reasonを優先度を決めて取り出せるようにした

### stop_reasonの優先度について
今回考慮すべきstop_reasonは以下の通りである

- STOP_LINE
- DETECTION_AREA
- OBSTACLE_STOP
- SURROUND_OBSTACLE_CHECK
- VIRTUAL_TRAFFIC_LIGHT

結果として、優先順位判定ロジックを以下の通りとする

1. 距離が両方とも0の場合
    1. SURROUND_OBSTACLE_CHECK
    2. OBSTACLE_STOP
    3. DETECTION_AREA
    4. VIRTUAL_TRAFFIC_LIGHT
    5. STOP_LINE 
2. 距離がより近い方を選択

### 参考：音声発話の優先順位
https://app.box.com/file/860109836014?s=9ss1fizbo587ecaqyz6r7llo1cak21j6

## Related Links
https://tier4.atlassian.net/browse/AEAP-560

## Tests Performed
上記チケットにて確認