### PR TITLE
feat: fix abnormal 402 transition

### DIFF
--- a/include/autoware_state_machine/autoware_state_machine.hpp
+++ b/include/autoware_state_machine/autoware_state_machine.hpp
@@ -125,7 +125,6 @@ private:
   bool is_engage_requesting_;
   bool is_engage_accepted_;
   double velocity_;
-  double engage_threshold_velocity_;
   double stop_threshold_velocity_;
   int32_t turn_signal_;
   bool flag_init_state_machine_;

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -1430,7 +1430,6 @@ AutowareStateMachine::AutowareStateMachine(
 
   // Adjustment Parameter
   update_rate = 1.0;
-  engage_threshold_velocity_ = 0.0278 * 3;  // 0.3[km/h]=0.0278 * 3[m/s]
   stop_threshold_velocity_ = 0.0278 * 3;  // 0.3[km/h]=0.0278 * 3[m/s]
   vehicle_state_overtime_ = 0.3;       // /awapi/autoware/get/status is received at 20ms intervals
   autoware_state_overtime_ = 0.3;      // /awapi/vehicle/get/status is received at 20ms intervals

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -1012,28 +1012,6 @@ ChangeStateReturnItem AutowareStateMachine::changeState4RunAndStop(void)
     }
 
     if (stop_reason_ == "") {
-      const auto isStopState =
-        (current_service_layer_state_ ==
-        autoware_state_machine_msgs::msg::StateMachine::STATE_STOP_DUETO_APPROACHING_OBSTACLE) ||
-        (current_service_layer_state_ ==
-        autoware_state_machine_msgs::msg::StateMachine::STATE_STOP_DUETO_SURROUNDING_PROXIMITY) ||
-        (current_service_layer_state_ ==
-        autoware_state_machine_msgs::msg::StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION);
-
-      /* Suspension without reason is treated as STATE_STOP_DUETO_TRAFFIC_CONDITION.
-         If there is no request to restart vehicle and vehicle start running,
-          it will exceptionally transition to STATE_RUNNING, STATE_TURNING_LEFT, or STATE_TURNING_RIGHT. */
-      if (isStopState && (velocity_ < engage_threshold_velocity_)) {
-        if (current_service_layer_state_ ==
-          autoware_state_machine_msgs::msg::StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION)
-        {
-          return ChangeStateReturnItem::NONE;
-        } else {
-          current_service_layer_state_ =
-            autoware_state_machine_msgs::msg::StateMachine::STATE_STOP_DUETO_TRAFFIC_CONDITION;
-          return ChangeStateReturnItem::TRANSITION;
-        }
-      }
       if (turn_signal_ == tier4_vehicle_msgs::msg::TurnSignal::LEFT) {
         if (autoware_state_machine_msgs::msg::StateMachine::STATE_TURNING_LEFT !=
           current_service_layer_state_)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

- このPRはstop line付近ではない場所で「402：交通状況による停止」への遷移をなくすためのものである。
  - 上記遷移が発生すると車両が停止し続け、音声も再生されないだんまり停止状態になる可能性がある。

### 修正対応の背景
  - 車両が走行途中にstop line付近以外でだんまり停止してしまう現象が発生しており、この現象を解析したところ、停止線付近ではない場所で「402：交通状況による停止」へ遷移してしまったことが原因と判明した。「402：交通状況による停止」への遷移条件を確認したところ、stop line付近以外で停止する条件が存在しており、この条件による遷移によってstop line付近以外で「402：交通状況による停止」へ遷移してその状態が継続し、だんまり停止が発生したと考えられる。

   - 「402：交通状況による停止」へ遷移する条件
      １. /awapi/autoware/get/statusトピックのstop_reasonがSURROUND_OBSTACLE_CHECK、OBSTACLE_STOP、DETECTION_AREA、CROSSWALK以外で停車位置(stop line)までの距離が0.35m未満
      ２. /awapi/autoware/get/statusトピックのstop_reasonがなく、現在の状態が「403：障害物近接による停止」、「404：周囲近接による停止」で車両速度が0.3km/h未満

        - 条件1は走行時に停止線(stop line)で停止する際の遷移条件となる。
        - 条件2はstop lineではない場所で障害物近接で車両が停止していると遷移する可能性がある遷移条件で、stop lineに関係なく遷移してしまう。この遷移後に他の状態へ遷移しない場合は、音声が再生されずに車両が停止し続けるだんまり停止が発生する。
          - だんまり停止が発生すると、車両から音声も再生されないため、車両を近くで確認しても何が原因で車両が停止しているか判断できない問題が発生している。
      
### 修正内容
  - このだんまり停止の発生を防ぐため、「402：交通状況による停止」の状態遷移のうち条件2の状態遷移を削除する。
    - この対応により「403：障害物近接による停止」、「404：周囲近接による停止」の状態の場合にstop line付近以外で「402：交通状況による停止」への遷移が発生しなくなり、この状態遷移によるだんまり停止が発生しなくなる。
      - 「402：交通状況による停止」へ遷移しなくなるため、障害物近接時は「403：障害物近接による停止」、「404：周囲近接による停止」が維持され、それ以外の場合は走行が再開されるようになり、車両停止中は「403：障害物近接による停止」か「404：周囲近接による停止」のどちらかの状態のため、音声が再生されない問題が改善し、障害物が原因で停止していることを音声で判断可能になる。
    - 削除する状態遷移を利用する動作はないので、この修正による悪影響はない見込み。
   
    - 修正前の走行中の状態遷移
![image](https://github.com/user-attachments/assets/d8da9d8b-ace5-4f84-9f9e-75ff952c9263)
      ※1：飛び出しや理由がない停止からの再発車
      ※2：startリクエストが要求されないまま車が発進した場合の変則的な遷移。本来、想定されない挙動。

    - 修正後の走行中の状態遷移(赤字が修正箇所)
![image](https://github.com/user-attachments/assets/66c85133-7a6d-43b3-9eb8-91c619457ff5)
      ※1：飛び出しや理由がない停止からの再発車
      ※2：startリクエストが要求されないまま車が発進した場合の変則的な遷移。本来、想定されない挙動。


  - 修正案についてとautoware_state_machineで車両が走行中に取る状態遷移を全て記載した情報は以下を参照
    - [だんまり停止の現状整理と改善案](https://tier4.atlassian.net/wiki/spaces/EVA/pages/3450896830)


## Related links

<!-- Write the links related to this PR. -->

[管理チケット(AEAP-1788)](https://tier4.atlassian.net/browse/AEAP-1788)
[修正動作確認チケット(AEAP-1963)](https://tier4.atlassian.net/browse/AEAP-1963)

## Tests performed

<!-- Describe how you have tested this PR. -->

### 検証内容
  - Psimを用いて走行途中に疑似障害物を設置することでなんとか再現させた「404：周囲近接による停止」から「402：交通状況による停止」への状態遷移が発生する（交互に両方の状態へ遷移を繰り返す）rosbagを使用し、Lsimを用いて修正前後で動作がどのように変化するか確認した。
    - 評価に使用したrosbagのrviz(車両に重なる緑線はstop lineではない線)
      ![vlcsnap-2025-01-14-10h45m52s572](https://github.com/user-attachments/assets/c58e2b06-e8f2-419c-a3a6-ff798a51fbf0)

    #### 修正前の状態遷移
      - stop lineではない場所で障害物を検知して「404：周囲近接による停止」へ遷移し、その後数秒程度経過すると「402：交通状況による停止」へ遷移し、数秒おきに「404：周囲近接による停止」と「402：交通状況による停止」を繰り返した。
    #### 修正後の状態遷移
      - stop lineではない場所で障害物を検知して「404：周囲近接による停止」へ遷移し、その後数秒程度経過すると「306：右折中」へ遷移し、数秒おきに「404：周囲近接による停止」と「306：右折中」を繰り返した。
    - 上記結果より、stop lineではない場所で障害物が近接して車両が停止している場合に「402：交通状況による停止」への遷移が発生しなくなっていることが確認できた。


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
