### PR TITLE
feat: align the threshold with v4.0.7-a.1.0 to improve stopping accuracy

### DIFF
--- a/launch/autoware_state_machine.launch.xml
+++ b/launch/autoware_state_machine.launch.xml
@@ -21,6 +21,6 @@
     <remap from="input/delivery_reservation_button" to="/delivery_reservation_button" />
     <param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)" />
     <param name="use_overridable_vehicle" value="$(var use_overridable_vehicle)" />
-    <param name="stop_dist_to_prohibit_engage" value="0.30" />
+    <param name="stop_dist_to_prohibit_engage" value="0.95" />
   </node>
 </launch>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

本PRは障害物音声案内が意図せず流れない不具合を改修するものである。

本不具合は、経路計画にて定義している再発車距離パラメータと本リポジトリにて管理されている
同種のパラメータ `prohibit_engage` との整合が取れていないことによって発生した。

経路計画におけるパラメータ値は、pilot-auto v4.0.7-a.1.0にて変更されており、
このバージョンにて整合を保つ必要がある。

このため本PRではpilot-auto v4.0.7-a.1.0向けに、
`prohibit_engage` パラメータを経路計画にて定義されているパラメータ値(=1.0)と整合させる。

### 詳細

本ノードでは、`prohibit_engage` に対してマジックナンバーで0.05の加算を行っている。
経路計画のパラメータ（=1.0）と整合させるため、本ノードとしての`prohibit_engage`パラメータを0.95に設定する。

## Related links

<!-- Write the links related to this PR. -->

[管理チケット](https://tier4.atlassian.net/browse/AEAP-2409)

## Tests performed
<!-- Describe how you have tested this PR. -->

### 機能評価

障害物との距離 1.0[m]を超えるまで、「障害物に対する停止状態(=403)」を維持、
距離1.0[m]を超えたら「発車音声案内(=305)」→「走行状態(=300)」への遷移を確認済み。

[test_perfomed.webm](https://github.com/user-attachments/assets/e275365d-46ed-40b4-b9e2-755afbbfd902)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/