### PR TITLE
fix: disable-restart-on-initial-departure

### DIFF
--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -216,7 +216,9 @@ void AutowareStateMachine::updateStateFromTopics()
     service_layer_state = StateMachine::STATE_INSTRUCT_ENGAGE;
   } else if (motion_state_.state == MotionState::STARTING && !has_started_driving_) {
     service_layer_state = StateMachine::STATE_INFORM_ENGAGE;
-  } else if (motion_state_.state == MotionState::STARTING && has_started_driving_) {
+  } else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && !driving_session_had_moving_) {
+    service_layer_state = StateMachine::STATE_INSTRUCT_ENGAGE; 
+  } else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && driving_session_had_moving_) {
     service_layer_state = StateMachine::STATE_INFORM_RESTART;
   } else if (
     motion_state_.state == MotionState::MOVING &&
@@ -271,6 +273,7 @@ void AutowareStateMachine::callbackMotionState(
   if (prev_motion_state_.state == MotionState::STOPPED &&
     motion_state_.state == MotionState::MOVING &&
     has_started_driving_ &&
+    driving_session_had_moving_ &&
     !is_playing_restart_sound_)
   {
     is_playing_restart_sound_ = true;


### PR DESCRIPTION
# Related Links
[管理チケット](https://tier4.atlassian.net/browse/AEAP-3964)

# Description
- 初回発車時にSTATE_INFORM_ENGAGE(301)とSTATE_INFORM_RESTART(450)の両方に遷移してしまうことから、「発車します」の音声が2回連続で流れる不具合を修正する。

以下部分を修正追加する
[初回発車時にRESTARTに遷移している原因のコード](https://github.com/eve-autonomy/autoware_state_machine/blob/feat/adapi-stateless-migration/src/autoware_state_machine.cpp#L219-L220)
```
else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && driving_session_had_moving_) {
    service_layer_state = StateMachine::STATE_INFORM_RESTART;
```
[初回発車時にRESTARTに遷移している原因のコード](https://github.com/eve-autonomy/autoware_state_machine/blob/feat/adapi-stateless-migration/src/autoware_state_machine.cpp#L271-L277)
```
if (prev_motion_state_.state == MotionState::STOPPED &&
    motion_state_.state == MotionState::MOVING &&
    has_started_driving_ &&
    driving_session_had_moving_ &&
    !is_playing_restart_sound_)
  {
    is_playing_restart_sound_ = true;
  }
```
以下を[該当コード](https://github.com/eve-autonomy/autoware_state_machine/blob/feat/adapi-stateless-migration/src/autoware_state_machine.cpp#L219-L220)の上に追加
```
else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && !driving_session_had_moving_) {
  service_layer_state = StateMachine::STATE_INSTRUCT_ENGAGE; 
```

# Test Performed
- [管理チケット](https://tier4.atlassian.net/browse/AEAP-3964)に記載。
- すべてPASSしたことを確認済み