### PR TITLE
fix: initial-start-recovery

### DIFF
--- a/include/autoware_state_machine/autoware_state_machine.hpp
+++ b/include/autoware_state_machine/autoware_state_machine.hpp
@@ -60,6 +60,7 @@ protected:
   bool emergency_holding_{false};
 
   // Session flags
+  bool stop_before_first_move_{false};
   bool has_started_driving_{false};
   bool driving_session_had_moving_{false};
   bool post_engage_sound_latched_{false};

--- a/src/autoware_state_machine.cpp
+++ b/src/autoware_state_machine.cpp
@@ -126,6 +126,7 @@ void AutowareStateMachine::updateStateFromTopics()
     route_state_.state != RouteState::SET ||
     localization_state_.state != LocalizationState::INITIALIZED)
   {
+    stop_before_first_move_ = false;
     has_started_driving_ = false;
     driving_session_had_moving_ = false;
   }
@@ -198,6 +199,9 @@ void AutowareStateMachine::updateStateFromTopics()
     route_state_.state == RouteState::SET &&
     (driving_session_had_moving_ || planning_p14_stop_factor))
   {
+    if (!driving_session_had_moving_) {
+      stop_before_first_move_ = true;
+    }
     const std::string & bname = planning_sel_name;
     if ((bname == "surround_obstacle_checker" || bname == "surrounding_obstacle") &&
       post_engage_sound_latched_)
@@ -217,7 +221,7 @@ void AutowareStateMachine::updateStateFromTopics()
   } else if (motion_state_.state == MotionState::STARTING && !has_started_driving_) {
     service_layer_state = StateMachine::STATE_INFORM_ENGAGE;
   } else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && !driving_session_had_moving_) {
-    service_layer_state = StateMachine::STATE_INSTRUCT_ENGAGE; 
+    service_layer_state = stop_before_first_move_ ? StateMachine::STATE_INFORM_RESTART : StateMachine::STATE_INSTRUCT_ENGAGE;
   } else if (motion_state_.state == MotionState::STARTING && has_started_driving_ && driving_session_had_moving_) {
     service_layer_state = StateMachine::STATE_INFORM_RESTART;
   } else if (
@@ -235,6 +239,7 @@ void AutowareStateMachine::updateStateFromTopics()
     route_state_.state == RouteState::SET)
   {
     driving_session_had_moving_ = true;
+    stop_before_first_move_ = false;
 
     const std::string & bname = planning_sel_name;
     if ((bname == "surround_obstacle_checker" || bname == "surrounding_obstacle") &&
@@ -311,6 +316,7 @@ void AutowareStateMachine::callbackRouteState(
     planning_selected_stop_reason_initialized_ = false;
     cached_planning_selected_nearest_ = {"", 0.0};
     driving_session_had_moving_ = false;
+    stop_before_first_move_ = false;
   }
 
   if (prev_route_state_.state != route_state_.state) {


### PR DESCRIPTION
# Related Links
[管理チケット](https://tier4.atlassian.net/browse/AEAP-3393)

# Description
- 初回発進時に車両周辺や一時停止線などによって、発進が妨げられた場合、その後再発進できない状態になっていたため修正を実施。
  -  周辺の障害物などが取り除かれた場合、STATE_INFORM_RESTART(450)に遷移して再発進させるようにする。

### 詳細
- 初回発進時にMOVINGに行かずに、障害物停車や停止線が近いときなどで停車したことを表すフラグを追加することで対策を行う
```
stop_before_first_move_
```


# Test Performed
- 管理チケットに記載